### PR TITLE
Power Debugger USB PID corrected

### DIFF
--- a/src/DebugToolDrivers/Microchip/PowerDebugger/PowerDebugger.hpp
+++ b/src/DebugToolDrivers/Microchip/PowerDebugger/PowerDebugger.hpp
@@ -18,7 +18,7 @@ namespace DebugToolDrivers::Microchip
     {
     public:
         static const inline std::uint16_t USB_VENDOR_ID = 0x03eb;
-        static const inline std::uint16_t USB_PRODUCT_ID = 0x2141;
+        static const inline std::uint16_t USB_PRODUCT_ID = 0x2144;
         static const inline std::uint8_t USB_CONFIGURATION_INDEX = 0;
         static const inline std::uint8_t CMSIS_HID_INTERFACE_NUMBER = 0;
 


### PR DESCRIPTION
This (micro-)PR corrects the Power Debugger USB PID. Currently, it is the PID of Atmel-ICE.